### PR TITLE
fix: add check for linux/blkdev.h existence before using it

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+liburing (2.8-1deepin1) unstable; urgency=medium
+
+  * Fix build on UOS kernel 6.6 without linux/blkdev.h.
+    - Add check for header existence before testing BLOCK_URING_CMD_DISCARD
+    - Fixes FTBFS on systems missing linux/blkdev.h header
+
+ -- lichenggang <lichenggang@deepin.org>  Fri, 20 Mar 2026 11:01:12 +0800
+
 liburing (2.8-1) unstable; urgency=medium
 
   * New upstream release.

--- a/debian/patches/fix-missing-blkdev.h.patch
+++ b/debian/patches/fix-missing-blkdev.h.patch
@@ -1,0 +1,51 @@
+From: lichenggang <lichenggang@uniontech.com>
+Date: Fri, 20 Mar 2026 10:00:00 +0800
+Subject: [PATCH] Fix build on systems without linux/blkdev.h
+
+Upstream commit 906a4567 added support for io_uring block discard commands
+which requires linux/blkdev.h for BLOCK_URING_CMD_DISCARD definition.
+However, this header is not available in kernel 6.6 (UOS environment).
+
+This patch modifies the configure script to check for the existence of
+linux/blkdev.h before attempting to use it. If the header is not present,
+the build gracefully falls back to defining BLOCK_URING_CMD_DISCARD locally
+in compat.h.
+
+Changes:
+- Add header existence check before testing BLOCK_URING_CMD_DISCARD
+- Prevents configure failure on systems without linux/blkdev.h
+- Maintains compatibility with newer kernels that have the header
+
+Signed-off-by: lichenggang <lichenggang@uniontech.com>
+---
+ configure | 13 ++++++++-----
+ 1 file changed, 9 insertions(+), 4 deletions(-)
+
+diff --git a/configure b/configure
+index 47943064..1fff5bdc 100755
+--- a/configure
++++ b/configure
+@@ -420,15 +420,20 @@ print_config "futex waitv support" "$futexv"
+ ##########################################
+ # Check block discard cmd support
+ discard_cmd="no"
+-cat > $TMPC << EOF
++# Check if linux/blkdev.h exists first
++if echo '#include <linux/blkdev.h>' | $cc -E -x c - >/dev/null 2>&1; then
++  cat > $TMPC << EOF
+ #include <linux/blkdev.h>
+ int main(void)
+ {
+   return BLOCK_URING_CMD_DISCARD;
+ }
+ EOF
+-if compile_prog "" "" "discard command"; then
+-  discard_cmd="yes"
++  if compile_prog "" "" "discard command"; then
++    discard_cmd="yes"
++  fi
+ fi
+ print_config "io_uring discard command support" "$discard_cmd"
+ 
+-- 
+2.40.0

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,0 +1,1 @@
+fix-missing-blkdev.h.patch


### PR DESCRIPTION
## 问题描述

上游提交 906a4567 添加了对 io_uring block discard 命令的支持，这需要 `linux/blkdev.h` 头文件中的 `BLOCK_URING_CMD_DISCARD` 定义。但是，在 UOS 环境（内核 6.6）中暂时没有 `linux/blkdev.h` 头文件，导致构建失败。

## 解决方案

修改 configure 脚本，在尝试使用 `linux/blkdev.h` 之前先检查该头文件是否存在。如果头文件不存在，构建将优雅地回退到在 compat.h 中本地定义 `BLOCK_URING_CMD_DISCARD`。

## 变更内容

- 在测试 `BLOCK_URING_CMD_DISCARD` 之前添加头文件存在性检查
- 防止在没有 `linux/blkdev.h` 的系统上配置失败
- 保持与有此头文件的新内核的兼容性

## 影响评估

- **向后兼容性**: 保持与所有内核版本的兼容性
- **功能影响**: 在 UOS 6.6 上，功能降级使用本地定义的宏值，功能正常
- **安全性**: 无安全影响

## 测试

- [x] 在支持 `linux/blkdev.h` 的系统上测试 configure 通过
- [x] Patch 文件已添加到 `debian/patches/`
- [x] Changelog 已更新

## 相关提交

- 上游提交: https://github.com/axboe/liburing/commit/906a4567312346a688ccb05ae94459cb00b889a6