### PR TITLE
        fix: add check for linux/blkdev.h existence before using it

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+liburing (2.8-1deepin1) unstable; urgency=medium
+
+  * Fix rebuild on UOS kernel 6.6 without linux/blkdev.h.
+    - Add check for header existence before testing BLOCK_URING_CMD_DISCARD
+    - Fixes FTBFS on systems missing linux/blkdev.h header
+
+ -- lichenggang <lichenggang@deepin.org>  Fri, 20 Mar 2026 11:01:12 +0800
+
 liburing (2.8-1) unstable; urgency=medium
 
   * New upstream release.


### PR DESCRIPTION
        Upstream commit 906a4567 added support for io_uring block discard commands
        which requires linux/blkdev.h for BLOCK_URING_CMD_DISCARD definition.
        However, this header is not available in kernel 6.6 (UOS environment).

        This patch modifies the configure script to check for the existence of
        linux/blkdev.h before attempting to use it. If the header is not present,
        the build gracefully falls back to defining BLOCK_URING_CMD_DISCARD locally
        in compat.h.

        Changes:
        - Add header existence check before testing BLOCK_URING_CMD_DISCARD
        - Prevents configure failure on systems without linux/blkdev.